### PR TITLE
sessions

### DIFF
--- a/alpinejs-plugin/package-lock.json
+++ b/alpinejs-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@livefir/fir",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@livefir/fir",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@alpinejs/morph": "^3.13.5",

--- a/alpinejs-plugin/package.json
+++ b/alpinejs-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livefir/fir",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/livefir/fir"

--- a/alpinejs-plugin/src/index.js
+++ b/alpinejs-plugin/src/index.js
@@ -6,7 +6,7 @@ const Plugin = (Alpine) => {
         return document.cookie
             .split('; ')
             .find((row) => row.startsWith('_fir_session_='))
-            ?.split('=')[1]
+            ?.substring(14)
     }
 
     // connect to websocket

--- a/cli/cmd/secret.go
+++ b/cli/cmd/secret.go
@@ -1,0 +1,33 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/gorilla/securecookie"
+	"github.com/spf13/cobra"
+)
+
+var size int
+
+// secretCmd generates a secret key using securecookie.GenerateRandomKey
+var secretCmd = &cobra.Command{
+	Use:   "secret",
+	Short: "Generates a hex secret key",
+	Long: `Generates a hex secret key for securecookie.GenerateRandomKey. 
+	This can be used with fir.WithSessionSecrets to set the session secret key. The default size is 32.
+	Please refer to: https://pkg.go.dev/github.com/gorilla/securecookie#New for more information.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		key := securecookie.GenerateRandomKey(size)
+		hexKey := hex.EncodeToString(key)
+		fmt.Println(hexKey)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(secretCmd)
+	secretCmd.Flags().IntVarP(&size, "size", "s", 32, "size of the secret key")
+}

--- a/controller.go
+++ b/controller.go
@@ -69,14 +69,16 @@ func WithFuncMap(funcMap template.FuncMap) ControllerOption {
 	}
 }
 
-func WithSecureCookie(s *securecookie.SecureCookie) ControllerOption {
+// WithSessionSecrets is an option to set the session secrets for the controller.
+// used to sign and encrypt the session cookie.
+func WithSessionSecrets(hashKey []byte, blockKey []byte) ControllerOption {
 	return func(o *opt) {
-		o.secureCookie = s
+		o.secureCookie = securecookie.New(hashKey, blockKey)
 	}
 }
 
-// WithCookieName is an option to set the cookie session name for the controller.
-func WithCookieName(name string) ControllerOption {
+// WithSessionName is an option to set the session name/cookie name for the controller.
+func WithSessionName(name string) ControllerOption {
 	return func(o *opt) {
 		o.cookieName = name
 	}

--- a/controller.go
+++ b/controller.go
@@ -191,7 +191,6 @@ func NewController(name string, options ...ControllerOption) Controller {
 	})
 
 	o := &opt{
-		channelFunc: defaultChannelFunc,
 		websocketUpgrader: websocket.Upgrader{
 			EnableCompression: true,
 			ReadBufferSize:    256,
@@ -253,6 +252,7 @@ func NewController(name string, options ...ControllerOption) Controller {
 	md := markdown(c.readFile, c.existFile)
 	c.funcMap["markdown"] = md
 	c.funcMap["md"] = md
+	c.opt.channelFunc = c.defaultChannelFunc
 
 	return c
 }

--- a/render.go
+++ b/render.go
@@ -3,7 +3,6 @@ package fir
 import (
 	"fmt"
 	"html/template"
-	"net/http"
 
 	"github.com/livefir/fir/internal/dom"
 	"github.com/livefir/fir/internal/eventstate"
@@ -40,20 +39,17 @@ func renderRoute(ctx RouteContext, errorRouteTemplate bool) routeRenderer {
 			return err
 		}
 
-		// encodedRouteID, err := ctx.route.cntrl.secureCookie.Encode(ctx.route.cookieName, ctx.route.id)
-		// if err != nil {
-		// 	logger.Errorf("error encoding cookie: %v", err)
-		// 	return err
-		// }
+		err = encodeSession(ctx.route.routeOpt, ctx.response, ctx.request)
+		if err != nil {
+			logger.Errorf("error encoding session: %v", err)
+			return err
+		}
 
-		http.SetCookie(ctx.response, &http.Cookie{
-			Name:   ctx.route.cookieName,
-			Value:  ctx.route.id,
-			MaxAge: 0,
-			Path:   "/",
-		})
-
-		ctx.response.Write(addAttributes(buf.Bytes()))
+		_, err = ctx.response.Write(addAttributes(buf.Bytes()))
+		if err != nil {
+			logger.Errorf("error writing response: %v", err)
+			return err
+		}
 		return nil
 	}
 }

--- a/route.go
+++ b/route.go
@@ -178,6 +178,7 @@ type route struct {
 	template       *template.Template
 	errorTemplate  *template.Template
 	eventTemplates eventTemplates
+	channel        string
 
 	cntrl *controller
 	routeOpt
@@ -195,15 +196,9 @@ func newRoute(cntrl *controller, routeOpt *routeOpt) *route {
 	return rt
 }
 
-func publishEvents(ctx context.Context, eventCtx RouteContext) eventPublisher {
+func publishEvents(ctx context.Context, eventCtx RouteContext, channel string) eventPublisher {
 	return func(pubsubEvent pubsub.Event) error {
-		channel := eventCtx.route.channelFunc(eventCtx.request, eventCtx.route.id)
-		if channel == nil {
-			logger.Errorf("error: channel is empty")
-			http.Error(eventCtx.response, "channel is empty", http.StatusUnauthorized)
-			return nil
-		}
-		err := eventCtx.route.pubsub.Publish(ctx, *channel, pubsubEvent)
+		err := eventCtx.route.pubsub.Publish(ctx, channel, pubsubEvent)
 		if err != nil {
 			logger.Errorf("error publishing patch: %v", err)
 			return err

--- a/route.go
+++ b/route.go
@@ -198,6 +198,11 @@ func newRoute(cntrl *controller, routeOpt *routeOpt) *route {
 func publishEvents(ctx context.Context, eventCtx RouteContext) eventPublisher {
 	return func(pubsubEvent pubsub.Event) error {
 		channel := eventCtx.route.channelFunc(eventCtx.request, eventCtx.route.id)
+		if channel == nil {
+			logger.Errorf("error: channel is empty")
+			http.Error(eventCtx.response, "channel is empty", http.StatusUnauthorized)
+			return nil
+		}
 		err := eventCtx.route.pubsub.Publish(ctx, *channel, pubsubEvent)
 		if err != nil {
 			logger.Errorf("error publishing patch: %v", err)
@@ -210,6 +215,11 @@ func publishEvents(ctx context.Context, eventCtx RouteContext) eventPublisher {
 func writeAndPublishEvents(ctx RouteContext) eventPublisher {
 	return func(pubsubEvent pubsub.Event) error {
 		channel := ctx.route.channelFunc(ctx.request, ctx.route.id)
+		if channel == nil {
+			logger.Errorf("error: channel is empty")
+			http.Error(ctx.response, "channel is empty", http.StatusUnauthorized)
+			return nil
+		}
 		err := ctx.route.pubsub.Publish(ctx.request.Context(), *channel, pubsubEvent)
 		if err != nil {
 			logger.Errorf("error publishing patch: %v", err)

--- a/session.go
+++ b/session.go
@@ -29,13 +29,13 @@ func decodeSession(sc securecookie.SecureCookie, cookieName, cookieValue string)
 }
 
 func encodeSession(opt routeOpt, w http.ResponseWriter, r *http.Request) error {
+	var sessionID string
 	cookie, err := r.Cookie(opt.cookieName)
-	if err != nil {
-		return err
-	}
-	sessionID, _, _ := decodeSession(*opt.secureCookie, opt.cookieName, cookie.Value)
-	if sessionID == "" {
-		sessionID = uuid.New().String()
+	if err == nil && cookie != nil {
+		sessionID, _, _ = decodeSession(*opt.secureCookie, opt.cookieName, cookie.Value)
+		if sessionID == "" {
+			sessionID = uuid.New().String()
+		}
 	}
 
 	session := sessionID + ":" + opt.id

--- a/session.go
+++ b/session.go
@@ -1,0 +1,54 @@
+package fir
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/securecookie"
+)
+
+var errInvalidSession = errors.New("invalid session")
+var errEmptySession = errors.New("empty session")
+
+func decodeSession(sc securecookie.SecureCookie, cookieName, cookieValue string) (string, string, error) {
+	var session string
+	if err := sc.Decode(cookieName, cookieValue, &session); err != nil {
+		return "", "", err
+	}
+	if session == "" {
+		return "", "", errEmptySession
+	}
+
+	parts := strings.Split(session, ":")
+	if len(parts) != 2 {
+		return "", "", errInvalidSession
+	}
+	return parts[0], parts[1], nil
+}
+
+func encodeSession(opt routeOpt, w http.ResponseWriter, r *http.Request) error {
+	cookie, err := r.Cookie(opt.cookieName)
+	if err != nil {
+		return err
+	}
+	sessionID, _, _ := decodeSession(*opt.secureCookie, opt.cookieName, cookie.Value)
+	if sessionID == "" {
+		sessionID = uuid.New().String()
+	}
+
+	session := sessionID + ":" + opt.id
+
+	encodedSessionID, err := opt.secureCookie.Encode(opt.cookieName, session)
+	if err != nil {
+		return err
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:   opt.cookieName,
+		Value:  encodedSessionID,
+		MaxAge: 0,
+		Path:   "/",
+	})
+	return nil
+}


### PR DESCRIPTION
- use cookie based sessions to authenticate websocket events and create channels by default
- add new cmd to generate secrets to secure fir sessions
- don't invoke channelfunc on every publish
- generate new session if session id missing or invalid
- options to securecookie name and keys
- update version
